### PR TITLE
Sketch Ledger workaround for unknown issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "@multiversx/sdk-hw-provider",
-  "version": "3.0.1",
+  "version": "3.0.2-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-hw-provider",
-      "version": "3.0.1",
+      "version": "3.0.2-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@ledgerhq/hw-transport": "^6.27.2",
+        "@ledgerhq/devices": "7.0.6",
+        "@ledgerhq/errors": "6.12.2",
+        "@ledgerhq/hw-transport": "6.27.9",
         "@ledgerhq/hw-transport-u2f": "5.36.0-deprecated",
         "@ledgerhq/hw-transport-webhid": "6.11.2",
         "@ledgerhq/hw-transport-webusb": "6.11.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-hw-provider",
-  "version": "3.0.2-alpha.3",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-hw-provider",
-      "version": "3.0.2-alpha.3",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@ledgerhq/devices": "7.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@multiversx/sdk-hw-provider",
-  "version": "3.0.2-alpha.1",
+  "version": "3.0.2-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@multiversx/sdk-hw-provider",
-      "version": "3.0.2-alpha.1",
+      "version": "3.0.2-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@ledgerhq/devices": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-hw-provider",
-  "version": "3.0.1",
+  "version": "3.0.2-alpha.1",
   "description": "Signing provider for dApps: hardware wallet (Ledger)",
   "main": "out/index.js",
   "types": "out/index.d.js",
@@ -17,10 +17,12 @@
   "author": "MultiversX",
   "license": "MIT",
   "dependencies": {
-    "@ledgerhq/hw-transport": "^6.27.2",
+    "@ledgerhq/hw-transport": "6.27.9",
     "@ledgerhq/hw-transport-u2f": "5.36.0-deprecated",
     "@ledgerhq/hw-transport-webhid": "6.11.2",
     "@ledgerhq/hw-transport-webusb": "6.11.2",
+    "@ledgerhq/devices": "7.0.6",
+    "@ledgerhq/errors": "6.12.2",
     "buffer": "6.0.3",
     "platform": "1.3.6"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-hw-provider",
-  "version": "3.0.2-alpha.3",
+  "version": "3.0.3",
   "description": "Signing provider for dApps: hardware wallet (Ledger)",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-hw-provider",
-  "version": "3.0.2-alpha.1",
+  "version": "3.0.2-alpha.2",
   "description": "Signing provider for dApps: hardware wallet (Ledger)",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-hw-provider",
-  "version": "3.0.2-alpha.2",
+  "version": "3.0.2-alpha.3",
   "description": "Signing provider for dApps: hardware wallet (Ledger)",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/ledgerApp.ts
+++ b/src/ledgerApp.ts
@@ -53,12 +53,12 @@ export default class LedgerApp {
         let address = response.subarray(1, 1 + addressLength).toString("ascii");
 
         // Workaround for yet-unknown Ledger issue.
-        const characters = address.split(",");
-        if (characters.length == 1) {
+        const parts = address.split(",");
+        if (parts.length == 1) {
             return { address };
         }
 
-        address = Buffer.from(characters.map(character => parseInt(character.trim()))).toString("ascii");
+        address = Buffer.from(parts.map(character => parseInt(character.trim()))).toString("ascii");
         return { address };
     }
 

--- a/src/ledgerApp.ts
+++ b/src/ledgerApp.ts
@@ -50,8 +50,15 @@ export default class LedgerApp {
         const response = await this.transport.send(CLA, ins, p1, p2, data);
 
         const addressLength = response[0];
-        const address = response.subarray(1, 1 + addressLength).toString("ascii");
+        let address = response.subarray(1, 1 + addressLength).toString("ascii");
 
+        // Workaround for yet-unknown Ledger issue.
+        const characters = address.split(",");
+        if (characters.length == 0) {
+            return { address };
+        }
+
+        address = Buffer.from(characters.map(character => parseInt(character.trim()))).toString("ascii");
         return { address };
     }
 
@@ -120,7 +127,7 @@ export default class LedgerApp {
         const response = await this.transport.send(0xed, 0x02, 0x00, 0x00);
         let accountIndex = 0;
         let addressIndex = 0;
-        if(response.length === 14){ // check if the response if from a version newer than 1.0.16
+        if (response.length === 14) { // check if the response if from a version newer than 1.0.16
             accountIndex = this.getIntValueFromBytes(response.slice(6, 10));
             addressIndex = this.getIntValueFromBytes(response.slice(10, 14));
         }

--- a/src/ledgerApp.ts
+++ b/src/ledgerApp.ts
@@ -54,7 +54,7 @@ export default class LedgerApp {
 
         // Workaround for yet-unknown Ledger issue.
         const characters = address.split(",");
-        if (characters.length == 0) {
+        if (characters.length == 1) {
             return { address };
         }
 

--- a/src/ledgerApp.ts
+++ b/src/ledgerApp.ts
@@ -50,15 +50,7 @@ export default class LedgerApp {
         const response = await this.transport.send(CLA, ins, p1, p2, data);
 
         const addressLength = response[0];
-        let address = response.subarray(1, 1 + addressLength).toString("ascii");
-
-        // Workaround for yet-unknown Ledger issue.
-        const parts = address.split(",");
-        if (parts.length == 1) {
-            return { address };
-        }
-
-        address = Buffer.from(parts.map(character => parseInt(character.trim()))).toString("ascii");
+        const address = Buffer.from(response.subarray(1, 1 + addressLength)).toString("ascii");
         return { address };
     }
 


### PR DESCRIPTION
In some circumstances (possibly related to the build pipeline of a dApp, but not necessarily; possibly related to recent patches in the `ledgerhq` NPM libraries, but not necessarily), in `LedgerApp.getAddress()`, the following is an **Array**, instead of a **Buffer**:

```
const response = await this.transport.send(CLA, ins, p1, p2, data);
const addressLength = response[0];
... response.subarray(1, 1 + addressLength); ...
```

If it's an Array instead of a Buffer, then the subsequent `toString("ascii")` returns `"101,114,100,49,..."` instead of `"erd1..."`.

We've added an extra Buffer wrapping step, to ensure that `toString("ascii")` works fine:

```
const address = Buffer.from(response.subarray(1, 1 + addressLength)).toString("ascii");
```

Additionally, we've locked the versions of Ledger dependencies, due to possibly a breaking change brought by a patch - which would have resulted in the following build error:

```
Property 'nanoFTS' is missing in type 'import("/.../node_modules/@ledgerhq/devices/lib/index").DeviceModelId'.
    return await TransportWebHID.open("");
```